### PR TITLE
Ensure use of integer of control_flow_functions

### DIFF
--- a/augmentoolkit/control_flow_functions/control_flow_functions.py
+++ b/augmentoolkit/control_flow_functions/control_flow_functions.py
@@ -973,7 +973,9 @@ def sentence_chunking_algorithm(file_path, max_char_length=1900):
     # add tokens to the paragraph until we reach the max length,
     # create chunks out of the remainder of the paragraph (split at max chunk length until it's done)
     # if the final chunk does not have the max length, then make it the new current chunk, set the current token count to its length, and continue with the for loop.
-
+    # Ensure max_char_length is an integer
+    max_char_length = int(max_char_length)
+    
     for paragraph in paragraphs:
         paragraph = paragraph.strip()  # Remove leading and trailing whitespace
         if not paragraph:  # Skip empty paragraphs


### PR DESCRIPTION
should fixes the case i encountered 
985, in sentence_chunking_algorithm
    if paragraph_char_count > max_char_length:
TypeError: '>' not supported between instances of 'int' and 'str' , the code