### PR TITLE
Fix default config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 PATH:
-  INPUT: "./raw_text_input"
+  INPUT: "./raw_txt_input"
   OUTPUT: "./output"
   DEFAULT_PROMPTS: "./prompts" # the baseline prompt folder that Augmentoolkit falls back to if it can't find a step in the PROMPTS path
   PROMPTS: "./prompts" # Where Augmentoolkit first looks for prompts

--- a/processing.py
+++ b/processing.py
@@ -86,7 +86,10 @@ async def main():
       path = f"{INPUT_FOLDER}/**/*" + extension
       source_texts = source_texts + glob.glob(path, recursive=True)
 
-    print(source_texts)
+    if source_texts:
+        print(source_texts)
+    else:
+        print(f"No source texts found in: {INPUT_FOLDER}")
 
     # [ # add your texts here
     #     "./raw_txt_input/Simple Sabotage, by the Office of Strategic Services, published 1944.txt",


### PR DESCRIPTION
In `1f08d7d` the default config changed from `raw_txt_input` to `raw_text_input`. The error thrown (`IndexError`) wasn't helpful because it gets stuck on [`paragraphs_processed[0]`](https://github.com/e-p-armstrong/augmentoolkit/blob/master/processing.py#L165) or later [`filtered_worthy_for_questions[0]`](https://github.com/e-p-armstrong/augmentoolkit/blob/master/processing.py#L198).

I propose:

1. Reverting the config to be consistent with the [exemplar data](https://github.com/e-p-armstrong/augmentoolkit/tree/master/raw_txt_input)
2. Raising an exception if the directory does not exist or the glob returns an empty list
    - Here I have only printed a message
3. Consider slice indexing so that users don't see `IndexError` when in fact a directory doesn't exist.
    - if, however,  this should raise an exception
        - Then an empty `source_texts` should also raise one
    - else,  we should use, e.g. `paragraphs_processed[0:1]`
    