### PR TITLE
Allow Unicode in YAML and JSON files to avoid counting number of unicode characters incorrectly and easier debugging

### DIFF
--- a/augmentoolkit/generation_functions/generation_step_class.py
+++ b/augmentoolkit/generation_functions/generation_step_class.py
@@ -154,6 +154,7 @@ class GenerationStep:
                                 }
                             ],
                             default_flow_style=False,
+                            allow_unicode=True
                         )
                     return ret, timeout
                 except Exception as e:
@@ -163,7 +164,7 @@ class GenerationStep:
                         print(prompt)
                     else:
                         print("Messages:")
-                        print(yaml.dump(messages, default_flow_style=False))
+                        print(yaml.dump(messages, default_flow_style=False, allow_unicode=True))
                     try:
                         print("\n\nResponse:\n-----\n")
                         print(response)

--- a/augmentoolkit/generation_functions/pipeline_step_class.py
+++ b/augmentoolkit/generation_functions/pipeline_step_class.py
@@ -109,7 +109,7 @@ class PipelineStep:
         
         os.makedirs(self.save_path, exist_ok=True)
         with open(save_path_file, "w") as f:
-            f.write(json.dumps(output_data))
+            f.write(json.dumps(output_data, ensure_ascii=False))
         
         output_list.append(output_data)
         return output_data

--- a/classifier_creator/processing.py
+++ b/classifier_creator/processing.py
@@ -221,7 +221,7 @@ async def main():
         await run_async_many(engine_wrapper=engine_wrapper, input_list=train_data, func=create_label, output_list=text_label_dicts, classes=USER_CLASSES)
     
     with open(os.path.join(config["PATH"]["OUTPUT"], "TEST_DEBUG_OUTPUT_OF_LIST"),  'w') as f:
-        f.write(json.dumps(text_label_dicts))
+        f.write(json.dumps(text_label_dicts, ensure_ascii=False))
     
     classifier_counter = 0
     output_dir = os.path.join(config["PATH"]["OUTPUT"], "classifiers")

--- a/classifier_creator/steps.py
+++ b/classifier_creator/steps.py
@@ -214,7 +214,7 @@ def train_classifier(text_label_dicts, classifier_counter, output_dir):
                 "text": d["paragraph"],
                 "label": d["label"]
             }
-            f.write(json.dumps(json_obj) + "\n")
+            f.write(json.dumps(json_obj, ensure_ascii=False) + "\n")
 
     ### TRAINING CODE
     dataset = load_dataset("json", data_files=path_to_dataset)
@@ -302,7 +302,7 @@ def run_classifier(input_list=None, model=None, output_dir=None, output_list=Non
                 f.write(json.dumps({
                     "text": inp[0],
                     "label": outputs[idx]
-                }))
+                }, ensure_ascii=False))
             
             out_tup = (inp[0], inp[1], outputs[idx])
             output_list.append(out_tup)
@@ -369,7 +369,7 @@ def save_train_set(test_label_dicts, output_dir):
                 "text": d["paragraph"],
                 "label": d["label"]
             }
-            f.write(json.dumps(json_obj) + "\n")
+            f.write(json.dumps(json_obj, ensure_ascii=False) + "\n")
         
         
 def fix_text(to_replace_arr, text):

--- a/original/steps.py
+++ b/original/steps.py
@@ -110,7 +110,7 @@ def convert_logging_to_dataset(input_pth=None, output_pth=None):
             
             json_to_write = {"conversations": [sysprompt, input, output]}
             
-            f.write(json.dumps(json_to_write) + "\n")
+            f.write(json.dumps(json_to_write, ensure_ascii=False) + "\n")
             full_list_of_dicts.append(json_to_write)
     print("...Converted successfully (we think)")
     
@@ -118,7 +118,7 @@ def convert_logging_to_dataset(input_pth=None, output_pth=None):
     with open(dataset_with_split_output_file_path, "w") as f:
             json_to_write = {"train": full_list_of_dicts}
             
-            f.write(json.dumps(json_to_write) + "\n")
+            f.write(json.dumps(json_to_write, ensure_ascii=False) + "\n")
             
     
     if PUSH_TO_HUB:
@@ -175,7 +175,7 @@ def convert_revised_questions_to_question_generation_training(qa_dicts_by_text, 
             answer_obj = {"from": "gpt", "value": answer}
             
             convo = {"conversations": [sysprompt_obj, input_obj, answer_obj]}
-            out_file.write(json.dumps(convo) + "\n")
+            out_file.write(json.dumps(convo, ensure_ascii=False) + "\n")
             convos.append(convo)
 
     print("...Converted successfully (we think)")
@@ -320,7 +320,7 @@ class ContextRepairer(PipelineStep):
         os.makedirs(self.save_path_dir, exist_ok=True)
         if output_list[idx]:
             with open(self.make_save_path_file(idx), "w") as f:
-                f.write(json.dumps(output_list[idx]))
+                f.write(json.dumps(output_list[idx], ensure_ascii=False))
         else:
             with open(self.make_save_path_file(idx), "w") as f:
                 f.write("failed")
@@ -1245,13 +1245,13 @@ def convert_directory_to_list(directory_path):
     write_1 = obj_conf["PATH"]["OUTPUT"] + "/master_list.jsonl"
     with open(write_1, "w") as file:
         for item in master_list:
-            file.write(json.dumps(item) + "\n")
+            file.write(json.dumps(item, ensure_ascii=False) + "\n")
 
     # Process and push simplified_list (no RAG)
     write_2 = obj_conf["PATH"]["OUTPUT"] + "/simplified_data_no_rag.jsonl"
     with open(write_2, "w") as file:
         for item in simplified_list:
-            file.write(json.dumps(item) + "\n")
+            file.write(json.dumps(item, ensure_ascii=False) + "\n")
             
 
     if PUSH_TO_HUB:
@@ -1273,12 +1273,12 @@ def convert_directory_to_list(directory_path):
     write_3 = obj_conf["PATH"]["OUTPUT"] + "/simplified_data_rag.jsonl"
     with open(write_3, "w") as file:
         for item in simplified_rag_list:
-            file.write(json.dumps(item) + "\n")
+            file.write(json.dumps(item, ensure_ascii=False) + "\n")
             
     write_4 = obj_conf["PATH"]["OUTPUT"] + "/plain_qa_list.jsonl"
     with open(write_4, "w") as file:
         for item in plain_qa_list:
-            file.write(json.dumps(item) + "\n")
+            file.write(json.dumps(item, ensure_ascii=False) + "\n")
     if PUSH_TO_HUB:
         # Create a temporary JSON file with train split
         temp_file_plain = obj_conf["PATH"]["OUTPUT"] + "/temp_plain_qa_list.json"
@@ -1335,12 +1335,12 @@ def save_plain_qatuples(qa_dicts_by_text):
     write_1 = obj_conf["PATH"]["OUTPUT"] + "/master_list.jsonl"
     with open(write_1, "w") as file:
         for item in master_list:
-            file.write(json.dumps(item) + "\n")
+            file.write(json.dumps(item, ensure_ascii=False) + "\n")
             
     write_2 = obj_conf["PATH"]["OUTPUT"] + "/plain_qa_list.jsonl"
     with open(write_2, "w") as file:
         for item in plain_qa_list:
-            file.write(json.dumps(item) + "\n")
+            file.write(json.dumps(item, ensure_ascii=False) + "\n")
     if PUSH_TO_HUB:
         # Create a temporary JSON file with train split
         temp_file_plain = obj_conf["PATH"]["OUTPUT"] + "/temp_plain_qa_list.json"

--- a/rptoolkit/steps.py
+++ b/rptoolkit/steps.py
@@ -262,7 +262,7 @@ class DepthFirstPipelineStep(PipelineStep): # RPTOOLKIT is depth-first rather th
             
             os.makedirs(self.save_path, exist_ok=True)
             with open(save_path_file, "w",encoding='utf-8') as f:
-                f.write(json.dumps(output_data))
+                f.write(json.dumps(output_data, ensure_ascii=False))
             
             return output_data
     

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -71,7 +71,7 @@ def scan_folders_for_config():
 # Save the updated config to the YAML file
 def save_yaml_config(data, filepath):
     with open(filepath, "w") as f:
-        yaml.dump(data, f, default_flow_style=False)
+        yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
 
 def run_processing_script(folder_path, config_path, project_root):
     env = os.environ.copy()
@@ -108,7 +108,7 @@ def load_individual_config(filepath):
 # Save an individual config file
 def save_individual_config(data, filepath):
     with open(filepath, "w") as f:
-        yaml.dump(data, f, default_flow_style=False)
+        yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
 
 if 'unsaved_changes_made' not in st.session_state:
     st.session_state['unsaved_changes_made'] = False

--- a/utils_for_manual_use/classifier_backtesting/backtest_classifier.py
+++ b/utils_for_manual_use/classifier_backtesting/backtest_classifier.py
@@ -108,7 +108,7 @@ for dataset_name, dataset in datasets.items():
         # Save predictions to .jsonl file
         with open(OUTPUT_FILE_PATH, 'a') as f:
             for text, pred in zip(batch_texts, batch_predictions):
-                json_line = json.dumps({"text": text, "label": int(pred), "dataset": dataset_name})
+                json_line = json.dumps({"text": text, "label": int(pred), "dataset": dataset_name}, ensure_ascii=False)
                 f.write(json_line + '\n')
         
         # Calculate and print current accuracy

--- a/utils_for_manual_use/convert_text_to_jsonl.py
+++ b/utils_for_manual_use/convert_text_to_jsonl.py
@@ -11,7 +11,7 @@ def txt_to_single_jsonl(txt_file_path, jsonl_file_path):
     
     with open(jsonl_file_path, 'w', encoding='utf-8') as jsonl_file:
         # Write the single JSON object to the .jsonl file
-        jsonl_file.write(json.dumps(json_obj) + '\n')
+        jsonl_file.write(json.dumps(json_obj, ensure_ascii=False) + '\n')
 
 # Example usage
 txt_file_path = './raw_txt_input/on_war_clausewitz.txt'


### PR DESCRIPTION
This fixes an issue where max character count was counted 5 times more than the actual character for non-ASCII characters and makes it easier to view the generated YAML and JSON files.

I ended up doing it for both YAML and JSON across the application, except for the calls to OpenAPI. 

I unfortunately can not test all the functionality I am updating myself, but the main pipeline still runs it now produces files with all characters dispayed without escaping