### PR TITLE
two commits, console logs, and stronger regex for character names

### DIFF
--- a/run_augmentoolkit.py
+++ b/run_augmentoolkit.py
@@ -8,6 +8,19 @@ import yaml
 import argparse
 from pathlib import Path
 import json
+import io
+
+
+# ==============================================================================
+# FORCE UTF-8 FOR ALL I/O
+# where the default encoding is not UTF-8. It prevents UnicodeEncodeError
+# when printing characters that are not in the default system codepage.
+# ==============================================================================
+if sys.stdout.encoding != 'utf-8':
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', errors='replace')
+if sys.stderr.encoding != 'utf-8':
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8', errors='replace')
+# ==============================================================================
 
 from resolve_path import resolve_path
 


### PR DESCRIPTION
- [Force UTF-8 encoding for stdout and stderr](https://github.com/e-p-armstrong/augmentoolkit/commit/2d8b8d6a855d05f3ec39a05da88089ac093393ad)

- Added logic to wrap sys.stdout and sys.stderr with UTF-8 encoding to prevent UnicodeEncodeError when printing non-ASCII characters. This ensures consistent output encoding across different system locales.

-[changed Regex function to be stronger](https://github.com/e-p-armstrong/augmentoolkit/commit/95b07260b6db398dd3de7d0fee2674a46b7a9627)

-changed Regex to more strongly catch prefixes, Epithets and Roman numerals, 
-added dirty_speaker_name and clean_speaker_name, for different dialogue formatting in a roleplay
e.g; cinder (menacing): would be counted as cinder (menacing): for the character count when clearly the character name is actually cinder.