### PR TITLE
Add API key rotation and retries to EngineWrapper

### DIFF
--- a/augmentoolkit/generation_functions/engine_wrapper_class.py
+++ b/augmentoolkit/generation_functions/engine_wrapper_class.py
@@ -1,10 +1,13 @@
 import asyncio
 import uuid
-from openai import AsyncOpenAI
+from openai import AsyncOpenAI, RateLimitError, APIStatusError
 import cohere
 from httpx import Timeout
 import traceback
 import json
+from collections import deque
+import functools
+import random
 
 
 def make_id():
@@ -26,34 +29,123 @@ class EngineWrapper:
         self,
         model,
         api_key=None,
+        api_keys=None,
         base_url=None,
-        mode="api",  # can be one of api, aphrodite, llama.cpp, cohere
+        mode="api",  # can be one of api, cohere
         input_observers=[],
         output_observers=[],
-        timeout_total=500.0,  # Total operation timeout
-        timeout_read=240.0,  # Read timeout between chunks
-        timeout_api_call=600,  # Timeout for individual API calls
+        timeout_api_call=600,
         **kwargs,
     ):
         self.mode = mode
         self.model = model
         self.input_observers = input_observers
         self.output_observers = output_observers
-        self.timeout_api_call = timeout_api_call  # Store for use in API calls
-        if mode == "cohere":
-            self.client = cohere.AsyncClient(api_key=api_key)
-        elif mode == "api":
+        self.timeout_api_call = timeout_api_call
+        self.base_url = base_url
+
+        if api_keys:
+            self.api_keys = deque(api_keys)
+        elif api_key:
+            self.api_keys = deque([api_key])
+        else:
+            raise ValueError("No API key provided. Please supply either 'api_key' or 'api_keys'.")
+        
+        self.total_keys = len(self.api_keys)
+        if self.total_keys == 0:
+            raise ValueError("The provided 'api_keys' list cannot be empty.")
+
+        self._rotation_lock = asyncio.Lock()
+        self._reinitialize_client()
+
+    def _reinitialize_client(self):
+        if not self.api_keys:
+             raise Exception("All API keys have been exhausted.")
+        
+        current_key = self.api_keys[0]
+        key_preview = f"{current_key[:4]}...{current_key[-4:]}" if len(current_key) > 8 else current_key
+        print(f"\n[EngineWrapper] Initializing client for model '{self.model}' with key: {key_preview}\n")
+
+        if self.mode == "cohere":
+            self.client = cohere.AsyncClient(api_key=current_key, max_retries=0)
+        elif self.mode == "api":
             self.client = AsyncOpenAI(
                 timeout=Timeout(
-                    timeout=timeout_total,  # Total operation timeout
-                    connect=10.0,  # Connection timeout
-                    read=timeout_read,  # Read timeout between chunks (increased for streaming)
-                    write=30.0,  # Write timeout
-                    pool=10.0,  # Pool timeout
+                    timeout=self.timeout_api_call,
+                    connect=10.0,
+                    read=self.timeout_api_call - 10,
+                    write=30.0,
+                    pool=10.0,
                 ),
-                api_key=api_key,
-                base_url=base_url,
+                api_key=current_key,
+                base_url=self.base_url,
+                max_retries=0,
             )
+
+    def _rotate_key_and_reinit(self):
+        self.api_keys.rotate(-1)
+        self._reinitialize_client()
+
+    async def _api_call_with_retry(self, method_path, **kwargs):
+        """
+        Makes an API call with a two-tiered retry system:
+        1. Inner Loop: Retries on transient server errors (5xx) with exponential backoff.
+        2. Outer Loop: Rotates API keys on client errors (429).
+        """
+        # Outer loop for iterating through API keys
+        for key_attempt in range(self.total_keys):
+            key_for_this_attempt = self.api_keys[0]
+            
+            # Inner loop for handling transient errors
+            max_transient_retries = 5
+            initial_backoff = 3.0  # seconds
+
+            for transient_retry_num in range(max_transient_retries):
+                try:
+                    method_to_call = functools.reduce(getattr, method_path.split('.'), self.client)
+                    return await method_to_call(**kwargs)
+
+                except (RateLimitError, APIStatusError) as e:
+                    status_code = getattr(e, 'status_code', 500)
+
+                    # Case 1: Rate limit/quota error (429). Stop retrying with this key.
+                    if status_code == 429:
+                        print(f"[EngineWrapper] Caught a 429 (Rate Limit/Quota) error. Rotating key.")
+                        # Break the inner loop to proceed to the key rotation logic below.
+                        break 
+                    
+                    # Case 2: Transient server error. Wait and retry with the same key.
+                    elif status_code in [404, 400, 500, 502, 503, 504]:
+                        if transient_retry_num < max_transient_retries - 1:
+                            wait_time = (initial_backoff ** transient_retry_num) + random.uniform(0, 1)
+                            print(f"[EngineWrapper] Caught a transient server error ({status_code}). Retrying in {wait_time:.2f} seconds...")
+                            await asyncio.sleep(wait_time)
+                            # Continue the inner loop to retry the request.
+                            continue
+                        else:
+                            print(f"[EngineWrapper] Caught a transient server error ({status_code}). Max retries reached for this key.")
+                            # Break the inner loop to let the outer loop try the next key.
+                            break
+                    
+                    # Case 3: Other client-side error (4xx). This is a permanent failure for this request.
+                    else:
+                        print(f"[EngineWrapper] Caught a non-retriable API error ({status_code}).")
+                        raise e
+
+                except Exception as e:
+                    print(f"[EngineWrapper] An unexpected network or client error occurred: {e}")
+                    traceback.print_exc()
+                    raise e
+            
+            # This block is reached if the inner loop breaks (either from a 429 or max transient retries).
+            async with self._rotation_lock:
+                if self.api_keys[0] == key_for_this_attempt:
+                    print("[EngineWrapper] This task is rotating the key.")
+                    self._rotate_key_and_reinit()
+                else:
+                    print("[EngineWrapper] Key was already rotated by another task. Using the new key.")
+        
+        raise Exception("All API keys and retry attempts failed.")
 
     async def submit_completion(
         self, prompt, sampling_params, return_completion_only=False
@@ -85,39 +177,42 @@ class EngineWrapper:
         if self.mode == "api":
             timed_out = False
             completion = ""
-            if use_min_p:
-                stream = await self.client.completions.create(
-                    model=self.model,
-                    prompt=prompt,
-                    temperature=sampling_params["temperature"],
-                    top_p=sampling_params["top_p"],
-                    stop=sampling_params["stop"],
-                    max_tokens=sampling_params["max_tokens"],
-                    extra_body={"min_p": sampling_params["min_p"]},
-                    stream=True,
-                    timeout=self.timeout_api_call,  # Use configurable timeout
-                )
-            else:
-                stream = await self.client.completions.create(
-                    model=self.model,
-                    prompt=prompt,
-                    temperature=sampling_params["temperature"],
-                    top_p=sampling_params["top_p"],
-                    stop=sampling_params["stop"],
-                    max_tokens=sampling_params["max_tokens"],
-                    stream=True,
-                    timeout=self.timeout_api_call,  # Use configurable timeout
-                )
-            async for chunk in stream:
-                try:
+            try:
+                if use_min_p:
+                    stream = await self._api_call_with_retry(
+                        "completions.create",
+                        model=self.model,
+                        prompt=prompt,
+                        temperature=sampling_params["temperature"],
+                        top_p=sampling_params["top_p"],
+                        stop=sampling_params["stop"],
+                        max_tokens=sampling_params["max_tokens"],
+                        extra_body={"min_p": sampling_params["min_p"]},
+                        stream=True,
+                        timeout=self.timeout_api_call,
+                    )
+                else:
+                    stream = await self._api_call_with_retry(
+                        "completions.create",
+                        model=self.model,
+                        prompt=prompt,
+                        temperature=sampling_params["temperature"],
+                        top_p=sampling_params["top_p"],
+                        stop=sampling_params["stop"],
+                        max_tokens=sampling_params["max_tokens"],
+                        stream=True,
+                        timeout=self.timeout_api_call,
+                    )
+                async for chunk in stream:
                     completion = completion + chunk.choices[0].text
-                except Exception as e:
-                    timed_out = True
+            except Exception as e:
+                timed_out = True
+                print(f"Exception during completion stream: {e}")
 
             for output_observer in self.output_observers:
                 output_observer(
                     prompt, completion, True
-                )  # input, output, completion_mode (this is the input format for output observers)
+                )
 
             if not return_completion_only:
                 return prompt + completion, timed_out
@@ -152,46 +247,44 @@ class EngineWrapper:
         if self.mode == "api":
             completion = ""
             timed_out = False
-            if use_min_p:
-                stream = await self.client.chat.completions.create(
-                    model=self.model,
-                    messages=messages,
-                    temperature=sampling_params["temperature"],
-                    top_p=sampling_params["top_p"],
-                    stop=sampling_params["stop"],
-                    max_tokens=sampling_params["max_tokens"],
-                    extra_body={"min_p": sampling_params["min_p"]},
-                    stream=True,
-                    timeout=self.timeout_api_call,  # Use configurable timeout
-                )
-            else:
-                stream = await self.client.chat.completions.create(
-                    model=self.model,
-                    messages=messages,
-                    temperature=sampling_params["temperature"],
-                    top_p=sampling_params["top_p"],
-                    stop=sampling_params["stop"],
-                    max_tokens=sampling_params["max_tokens"],
-                    stream=True,
-                    timeout=self.timeout_api_call,  # Use configurable timeout
-                )
-            async for chunk in stream:
-                try:
-                    # print(chunk.choices)
+            try:
+                if use_min_p:
+                    stream = await self._api_call_with_retry(
+                        "chat.completions.create",
+                        model=self.model,
+                        messages=messages,
+                        temperature=sampling_params["temperature"],
+                        top_p=sampling_params["top_p"],
+                        stop=sampling_params["stop"],
+                        max_tokens=sampling_params["max_tokens"],
+                        extra_body={"min_p": sampling_params["min_p"]},
+                        stream=True,
+                        timeout=self.timeout_api_call,
+                    )
+                else:
+                    stream = await self._api_call_with_retry(
+                        "chat.completions.create",
+                        model=self.model,
+                        messages=messages,
+                        temperature=sampling_params["temperature"],
+                        top_p=sampling_params["top_p"],
+                        stop=sampling_params["stop"],
+                        max_tokens=sampling_params["max_tokens"],
+                        stream=True,
+                        timeout=self.timeout_api_call,
+                    )
+                async for chunk in stream:
                     try:
                         if chunk.choices[0].delta.content:
                             completion = completion + chunk.choices[0].delta.content
-                    except Exception as e:
-                        # print("Really strange exception!")
-                        # print(chunk)
-                        # traceback.print_exc()
+                    except Exception:
                         pass
-                except Exception as e:
-                    print("\n\n------------CAUGHT EXCEPTION DURING GENERATION")
-                    print(e)
-                    traceback.print_exc()
-                    timed_out = True
-                    print("\n\n-----/\------")
+            except Exception as e:
+                print("\n\n------------CAUGHT EXCEPTION DURING GENERATION")
+                print(e)
+                traceback.print_exc()
+                timed_out = True
+                print("\n\n-----/\------")
 
             for output_observer in self.output_observers:
                 output_observer(messages, completion, False)
@@ -208,24 +301,24 @@ class EngineWrapper:
                 }
                 for message in messages
             ]
-            stream = self.client.chat_stream(
-                model=self.model,
-                chat_history=messages_cohereified[1:-1],
-                message=messages_cohereified[-1]["message"],
-                preamble=messages_cohereified[0]["message"],
-                temperature=sampling_params["temperature"],
-                p=sampling_params["top_p"],
-                stop_sequences=sampling_params["stop"],
-                max_tokens=sampling_params["max_tokens"],
-            )
-            async for chunk in stream:
-                try:
+            try:
+                stream = self.client.chat_stream(
+                    model=self.model,
+                    chat_history=messages_cohereified[1:-1],
+                    message=messages_cohereified[-1]["message"],
+                    preamble=messages_cohereified[0]["message"],
+                    temperature=sampling_params["temperature"],
+                    p=sampling_params["top_p"],
+                    stop_sequences=sampling_params["stop"],
+                    max_tokens=sampling_params["max_tokens"],
+                )
+                async for chunk in stream:
                     if chunk.event_type == "text-generation":
                         completion = completion + chunk.text
-                except Exception as e:
-                    print("THIS RESPONSE TIMED OUT PARTWAY THROUGH GENERATION!")
-                    print(e)
-                    timed_out = True
+            except Exception as e:
+                print("THIS RESPONSE TIMED OUT PARTWAY THROUGH GENERATION!")
+                print(e)
+                timed_out = True
 
             for output_observer in self.output_observers:
                 output_observer(messages, completion, False)
@@ -261,45 +354,45 @@ class EngineWrapper:
             input_observer(prompt, completion_mode=True)
 
         if self.mode == "api":
-            timed_out = False
             completion = ""
+            timed_out = False
+            stream = None
+            try:
+                if use_min_p:
+                    stream = await self._api_call_with_retry(
+                        "completions.create",
+                        model=self.model,
+                        prompt=prompt,
+                        temperature=sampling_params["temperature"],
+                        top_p=sampling_params["top_p"],
+                        stop=sampling_params["stop"],
+                        max_tokens=sampling_params["max_tokens"],
+                        extra_body={"min_p": sampling_params["min_p"]},
+                        stream=True,
+                        timeout=self.timeout_api_call,
+                    )
+                else:
+                    stream = await self._api_call_with_retry(
+                        "completions.create",
+                        model=self.model,
+                        prompt=prompt,
+                        temperature=sampling_params["temperature"],
+                        top_p=sampling_params["top_p"],
+                        stop=sampling_params["stop"],
+                        max_tokens=sampling_params["max_tokens"],
+                        stream=True,
+                        timeout=self.timeout_api_call,
+                    )
 
-            if use_min_p:
-                stream = await self.client.completions.create(
-                    model=self.model,
-                    prompt=prompt,
-                    temperature=sampling_params["temperature"],
-                    top_p=sampling_params["top_p"],
-                    stop=sampling_params["stop"],
-                    max_tokens=sampling_params["max_tokens"],
-                    extra_body={"min_p": sampling_params["min_p"]},
-                    stream=True,
-                    timeout=self.timeout_api_call,
-                )
-            else:
-                stream = await self.client.completions.create(
-                    model=self.model,
-                    prompt=prompt,
-                    temperature=sampling_params["temperature"],
-                    top_p=sampling_params["top_p"],
-                    stop=sampling_params["stop"],
-                    max_tokens=sampling_params["max_tokens"],
-                    stream=True,
-                    timeout=self.timeout_api_call,
-                )
-
-            async for chunk in stream:
-                try:
+                async for chunk in stream:
                     text_chunk = chunk.choices[0].text
                     completion += text_chunk
-                    # Yield chunk in SSE format
                     yield f"data: {json.dumps({'text': text_chunk, 'done': False})}\n\n"
-                except Exception as e:
-                    timed_out = True
-                    yield f"data: {json.dumps({'error': str(e), 'done': True})}\n\n"
-                    break
 
-            # Send completion signal
+            except Exception as e:
+                timed_out = True
+                yield f"data: {json.dumps({'error': str(e), 'done': True})}\n\n"
+
             if not timed_out:
                 yield f"data: {json.dumps({'text': '', 'done': True})}\n\n"
 
@@ -333,50 +426,49 @@ class EngineWrapper:
         if self.mode == "api":
             completion = ""
             timed_out = False
+            stream = None
+            try:
+                if use_min_p:
+                    stream = await self._api_call_with_retry(
+                        "chat.completions.create",
+                        model=self.model,
+                        messages=messages,
+                        temperature=sampling_params["temperature"],
+                        top_p=sampling_params["top_p"],
+                        stop=sampling_params["stop"],
+                        max_tokens=sampling_params["max_tokens"],
+                        extra_body={"min_p": sampling_params["min_p"]},
+                        stream=True,
+                        timeout=self.timeout_api_call,
+                    )
+                else:
+                    stream = await self._api_call_with_retry(
+                        "chat.completions.create",
+                        model=self.model,
+                        messages=messages,
+                        temperature=sampling_params["temperature"],
+                        top_p=sampling_params["top_p"],
+                        stop=sampling_params["stop"],
+                        max_tokens=sampling_params["max_tokens"],
+                        stream=True,
+                        timeout=self.timeout_api_call,
+                    )
 
-            if use_min_p:
-                stream = await self.client.chat.completions.create(
-                    model=self.model,
-                    messages=messages,
-                    temperature=sampling_params["temperature"],
-                    top_p=sampling_params["top_p"],
-                    stop=sampling_params["stop"],
-                    max_tokens=sampling_params["max_tokens"],
-                    extra_body={"min_p": sampling_params["min_p"]},
-                    stream=True,
-                    timeout=self.timeout_api_call,
-                )
-            else:
-                stream = await self.client.chat.completions.create(
-                    model=self.model,
-                    messages=messages,
-                    temperature=sampling_params["temperature"],
-                    top_p=sampling_params["top_p"],
-                    stop=sampling_params["stop"],
-                    max_tokens=sampling_params["max_tokens"],
-                    stream=True,
-                    timeout=self.timeout_api_call,
-                )
-
-            async for chunk in stream:
-                try:
+                async for chunk in stream:
                     try:
                         if chunk.choices[0].delta.content:
                             text_chunk = chunk.choices[0].delta.content
                             completion += text_chunk
-                            # Yield chunk in SSE format
                             yield f"data: {json.dumps({'text': text_chunk, 'done': False})}\n\n"
-                    except Exception as e:
+                    except Exception:
                         pass
-                except Exception as e:
-                    print("\n\n------------CAUGHT EXCEPTION DURING GENERATION")
-                    print(e)
-                    traceback.print_exc()
-                    timed_out = True
-                    yield f"data: {json.dumps({'error': str(e), 'done': True})}\n\n"
-                    break
+            except Exception as e:
+                print("\n\n------------CAUGHT EXCEPTION DURING GENERATION")
+                print(e)
+                traceback.print_exc()
+                timed_out = True
+                yield f"data: {json.dumps({'error': str(e), 'done': True})}\n\n"
 
-            # Send completion signal
             if not timed_out:
                 yield f"data: {json.dumps({'text': '', 'done': True})}\n\n"
 
@@ -393,29 +485,28 @@ class EngineWrapper:
                 }
                 for message in messages
             ]
-            stream = self.client.chat_stream(
-                model=self.model,
-                chat_history=messages_cohereified[1:-1],
-                message=messages_cohereified[-1]["message"],
-                preamble=messages_cohereified[0]["message"],
-                temperature=sampling_params["temperature"],
-                p=sampling_params["top_p"],
-                stop_sequences=sampling_params["stop"],
-                max_tokens=sampling_params["max_tokens"],
-            )
-            async for chunk in stream:
-                try:
+            try:
+                stream = self.client.chat_stream(
+                    model=self.model,
+                    chat_history=messages_cohereified[1:-1],
+                    message=messages_cohereified[-1]["message"],
+                    preamble=messages_cohereified[0]["message"],
+                    temperature=sampling_params["temperature"],
+                    p=sampling_params["top_p"],
+                    stop_sequences=sampling_params["stop"],
+                    max_tokens=sampling_params["max_tokens"],
+                )
+                async for chunk in stream:
                     if chunk.event_type == "text-generation":
                         text_chunk = chunk.text
                         completion += text_chunk
                         yield f"data: {json.dumps({'text': text_chunk, 'done': False})}\n\n"
-                except Exception as e:
-                    print("THIS RESPONSE TIMED OUT PARTWAY THROUGH GENERATION!")
-                    print(e)
-                    timed_out = True
-                    yield f"data: {json.dumps({'error': str(e), 'done': True})}\n\n"
-                    break
-
+            except Exception as e:
+                print("THIS RESPONSE TIMED OUT PARTWAY THROUGH GENERATION!")
+                print(e)
+                timed_out = True
+                yield f"data: {json.dumps({'error': str(e), 'done': True})}\n\n"
+                
             if not timed_out:
                 yield f"data: {json.dumps({'text': '', 'done': True})}\n\n"
 

--- a/external_configs/rptoolkit.yaml
+++ b/external_configs/rptoolkit.yaml
@@ -1,8 +1,12 @@
 pipeline: rptoolkit-pipeline
 
 api:
-  small_api_key: !!PLACEHOLDER!!
-  large_api_key: !!PLACEHOLDER!!
+  small_api_keys: # can also use use a single key
+    - "!!PLACEHOLDER!!"
+    - "!!PLACEHOLDER!!"
+  large_api_keys: # can also use use a single key
+    - "!!PLACEHOLDER!!"
+    - "!!PLACEHOLDER!!"
   small_base_url: https://api.deepinfra.com/v1/openai
   large_base_url: https://api.deepinfra.com/v1/openai # http://localhost:2242/v1
   small_model: deepseek-ai/DeepSeek-V3-0324

--- a/generation/core_components/setup_components.py
+++ b/generation/core_components/setup_components.py
@@ -7,17 +7,21 @@ import inspect
 def setup_semaphore_and_engines(
     concurrency_limit: int,
     small_model: str,
-    small_api_key: str,
+    # small_api_key: str,
     small_base_url: str,
     small_mode: str,
     large_model: str,
-    large_api_key: str,
+    # large_api_key: str,
     large_base_url: str,
     large_mode: str,
     engine_input_observers=[],
     engine_output_observers=[],
     large_engine_input_observers=[],
     large_engine_output_observers=[],
+    small_api_keys=None,
+    large_api_keys=None,
+    large_api_key=None,
+    small_api_key=None,
 ):
     semaphore = asyncio.Semaphore(concurrency_limit)
 
@@ -28,6 +32,7 @@ def setup_semaphore_and_engines(
     engine_wrapper = EngineWrapper(
         model=small_model,
         api_key=small_api_key,
+        api_keys=small_api_keys,
         base_url=small_base_url,
         mode=small_mode,
         input_observers=engine_input_observers,
@@ -37,6 +42,7 @@ def setup_semaphore_and_engines(
     engine_wrapper_large = EngineWrapper(
         model=large_model,
         api_key=large_api_key,
+        api_keys=large_api_keys,
         base_url=large_base_url,
         mode=large_mode,
         input_observers=large_engine_input_observers,

--- a/generation/core_pipelines/rptoolkit/rptoolkit.py
+++ b/generation/core_pipelines/rptoolkit/rptoolkit.py
@@ -1,6 +1,7 @@
 import random
 import traceback
 import asyncio
+import re
 from augmentoolkit.generation_functions.depth_first_pipeline_step_class import (
     DepthFirstPipelineStep,
     create_depth_first_executor,
@@ -344,8 +345,8 @@ async def rptoolkit_pipeline(
     completion_mode,
     small_model,
     large_model,
-    small_api_key,
-    large_api_key,
+    # small_api_key,
+    # large_api_key,
     small_base_url,
     large_base_url,
     small_mode,
@@ -365,6 +366,10 @@ async def rptoolkit_pipeline(
     meta_datagen_keys,
     meta_datagen_extras,
     to_include_features,
+    small_api_key=None,
+    large_api_key=None,
+    small_api_keys=None,
+    large_api_keys=None,
     chunking_output_dir=None,
     task_id=None,
     seed=1048596,
@@ -454,6 +459,8 @@ async def rptoolkit_pipeline(
             large_api_key,
             large_base_url,
             large_mode,
+            small_api_keys=small_api_keys,
+            large_api_keys=large_api_keys,
             engine_input_observers=[
                 create_input_token_counter(
                     counter=small_token_counter,

--- a/generation/core_pipelines/rptoolkit/rptoolkit_helpers.py
+++ b/generation/core_pipelines/rptoolkit/rptoolkit_helpers.py
@@ -748,8 +748,8 @@ def split_last_message_at_note(
             }
         ]
     return chatlog_list
-
-
+    
+# Default name prefixes to be stripped
 _DEFAULT_PREFIX_TITLES = (
     "Queen", "King", "Princess", "Prince", "General", "Lord",
     "Lady", "Captain", "Commander", "Warden", "professor", "Elder", "Magistrate", "Chancellor", 


### PR DESCRIPTION
Enhanced EngineWrapper to support multiple API keys with automatic rotation on rate limit errors and transient error retries. Updated configuration and setup to accept lists of API keys for both small and large models. Refactored pipeline and helper code to support these changes and improved error handling and logging throughout the engine wrapper.

-----

probably want to update all the .yaml examples to indicate the support of multiple api keys